### PR TITLE
Add stale issue workflow

### DIFF
--- a/.github/workflows/closeStaleIssues.yml
+++ b/.github/workflows/closeStaleIssues.yml
@@ -1,0 +1,23 @@
+name: Close Stale Issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 3
+          days-before-issue-close: 2
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has not received a response in 3 days. It will auto-close in 2 days unless a response is posted."
+          close-issue-message: "This issue is now closed due to inactivity. Feel free to reopen it if the problem persists"
+          operations-per-run: 100
+          exempt-issue-labels: announcement,bug,on hold,waiting for internal reply,feature, enhancement, owned by another team
+          any-of-labels: more information required,


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to auto-close stale issues

## Details
- Issues marked stale after 3 days without response
- Auto-closed 2 days after stale label
- Runs daily at 1:30 AM UTC
- Can be triggered manually via workflow_dispatch
- Exempts issues with important labels (bug, feature, etc.)
- Targets issues with "more information required" label