### PR TITLE
chore: align bug report template with Agentforce Vibes 4.x diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/a4d_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/a4d_bug_report.yml
@@ -31,10 +31,18 @@ body:
           label: Additional context
           description: Add any other context about the problem here, such as screenshots or related issues.
     - type: input
-      id: sf-telemetry-id
+      id: extension-version
       attributes:
-          label: Salesforce Telemetry ID
-          description: What is your Salesforce Telemetry ID? Acquire it by running `sf telemetry` in your terminal.
-          placeholder: "Salesforce CLI ID is 6a3b46564c9e3fc87ae614f61776a467be868a2e"
+          label: Agentforce Vibes version
+          description: From the Extensions view, or the top of "Copy Diagnostics". 4.x is a full replatform, so reports against older versions may already be fixed.
+          placeholder: "4.11.0"
       validations:
           required: true
+    - type: textarea
+      id: diagnostics
+      attributes:
+          label: Diagnostics
+          description: "Run `Cmd/Ctrl+Shift+P` -> `Agentforce: Copy Diagnostics` and paste the output. It is PII-scrubbed and includes the extension version, editor/OS, and a digest of recent failures. Please review before sharing."
+          render: text
+      validations:
+          required: false


### PR DESCRIPTION
## Summary

Updates the bug report issue template to match Agentforce Vibes 4.x, a full replatform of the 3.x extension. The old form required a **Salesforce Telemetry ID** (`sf telemetry`) — a 3.x/CLI-era field that no longer maps to how 4.x reports diagnostics.

### What changed
- **Removed** the required *Salesforce Telemetry ID* input.
- **Added** a required *Agentforce Vibes version* input — 4.x is a ground-up replatform, so version is the fastest signal for whether a report is already fixed. (It's also the first line of the Copy Diagnostics paste, so the dedicated field just makes it a searchable triage facet.)
- **Added** an optional *Diagnostics* textarea pointing reporters at `Cmd/Ctrl+Shift+P → Agentforce: Copy Diagnostics`. The output is PII-scrubbed (home paths, secrets, emails, org hosts, and known tokens redacted; conversation content excluded by design) and carries the extension version, editor/OS/hardware, MCP / Rules / Skills subsystem health, npm wrapper logs, and a digest of recent activity and failures over a chronological event log.

### Why
Recent reports against the 3.x line (e.g. #195) ask for a telemetry ID that 4.x users can't readily produce, and the more actionable signal in 4.x is the built-in **Copy Diagnostics** output plus the exact extension version. This nudges reporters toward upgrading and gives triage the data it actually needs.

## Test plan
- [ ] Confirm the form renders on a new-issue preview (GitHub validates `*.yml` issue forms on push).
- [ ] Verify the *Agentforce Vibes version* field is required and *Diagnostics* is optional.
